### PR TITLE
imap-dl support for Kerberos/GSSAPI (and ssl_ciphers)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -51,6 +51,7 @@ Recommends:
  git,
  notmuch,
  python3-argcomplete,
+ python3-gssapi,
  python3-pgpy,
 Suggests:
  gnutls-bin,

--- a/imap-dl
+++ b/imap-dl
@@ -17,22 +17,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-DESCRIPTION = '''A simple replacement for a minimalist use of getmail.
+DESCRIPTION = '''Fetch messages from an IMAP inbox into a maildir
 
-In particular, if you use getmail to reach an IMAP server as though it
-were POP (retrieving from the server and optionally deleting), you can
-point this script to the getmail config and it should do the same
-thing.
-
-It tries to ensure that the configuration file is of the expected
-type, and will terminate raising an exception, and it should not lose
-messages.
-
-If there's any interest in supporting other similarly simple use cases
-for getmail, patches are welcome.
-
-If you've never used getmail, you can make the simplest possible
-config file like so:
+Example config file:
 
 ----------
 [retriever]
@@ -46,6 +33,8 @@ path = /home/foo/Maildir
 [options]
 delete = True
 ----------
+
+Run "man imap-dl" for more details.
 '''
 
 import re

--- a/imap-dl
+++ b/imap-dl
@@ -80,6 +80,14 @@ summary_splitter = Splitter('summary', _summary_re)
 _fetch_re = rb'^(?P<id>[0-9]+) \(UID (?P<uid>[0-9]+) (FLAGS \([\\A-Za-z ]*\) )?BODY\[\] \{(?P<size>[0-9]+)\}$'
 fetch_splitter = Splitter('fetch', _fetch_re)
 
+def auth_builtin(username:str, imap:imaplib.IMAP4_SSL,
+                 conf:configparser.ConfigParser, server:str) -> None:
+    logging.info('Logging in as %s', username)
+    resp:Tuple[str, List[Union[bytes,Tuple[bytes,bytes]]]]
+    resp = imap.login(username, conf.get('retriever', 'password'))
+    if resp[0] != 'OK':
+        raise Exception(f'login failed with {resp} as user {username} on {server}')
+
 def scan_msgs(configfile:str, verbose:bool) -> None:
     conf = configparser.ConfigParser()
     conf.read_file(open(configfile, 'r'))
@@ -125,11 +133,7 @@ def scan_msgs(configfile:str, verbose:bool) -> None:
                            port=int(conf.get('retriever', 'port', fallback=993)),
                            ssl_context=ctx) as imap:
         username:str = conf.get('retriever', 'username')
-        logging.info('Logging in as %s', username)
-        resp:Tuple[str, List[Union[bytes,Tuple[bytes,bytes]]]]
-        resp = imap.login(username, conf.get('retriever', 'password'))
-        if resp[0] != 'OK':
-            raise Exception(f'login failed with {resp} as user {username} on {server}')
+        auth_builtin(username, imap, conf, server)
         if verbose: # only enable debugging after login to avoid leaking credentials in the log
             imap.debug = 4
         logging.info("capabilities reported: %s", ', '.join(imap.capabilities))

--- a/imap-dl
+++ b/imap-dl
@@ -50,12 +50,18 @@ import argparse
 import statistics
 import configparser
 
-from typing import Dict, List, Union, Tuple
+from typing import Dict, List, Optional, Tuple, Union
 
 try:
     import argcomplete #type: ignore
 except ImportError:
     argcomplete = None
+
+try:
+    import gssapi # type: ignore
+except ModuleNotFoundError:
+    gssapi = None
+
 
 class Splitter(object):
     def __init__(self, name:str, match:bytes):
@@ -87,6 +93,52 @@ def auth_builtin(username:str, imap:imaplib.IMAP4_SSL,
     resp = imap.login(username, conf.get('retriever', 'password'))
     if resp[0] != 'OK':
         raise Exception(f'login failed with {resp} as user {username} on {server}')
+
+# imaplib auth methods need to be in the form of callables, and they all
+# requre both additional parameters and storage beyond what the function
+# interface provides.
+class GSSAPI_handler():
+    gss_vc:gssapi.SecurityContext
+    username:str
+
+    def __init__(self, server:str, username:str) -> None:
+        name = gssapi.Name(f'imap@{server}', gssapi.NameType.hostbased_service)
+        self.gss_vc = gssapi.SecurityContext(usage="initiate", name=name)
+        self.username = username
+
+    def __call__(self, token:Optional[bytes]) -> bytes:
+        if token == b"":
+            token = None
+        if not self.gss_vc.complete:
+            response = self.gss_vc.step(token)
+            return response if response else b"" # type: ignore
+        elif token is None:
+            return b""
+
+        response = self.gss_vc.unwrap(token)
+
+        # Preserve the "length" of the message we received, and set the first
+        # byte to one.  If username is provided, it's next.
+        reply:List[int] = []
+        reply[0:4] = response.message[0:4]
+        reply[0] = 1
+        if self.username:
+            reply[5:] = self.username.encode("utf-8")
+
+        response = self.gss_vc.wrap(bytes(reply), response.encrypted)
+        return response.message if response.message else b"" # type: ignore
+
+def auth_gssapi(username:str, imap:imaplib.IMAP4_SSL,
+                conf:configparser.ConfigParser, server:str) -> None:
+    if not gssapi:
+        raise Exception('Kerberos requested, but python3-gssapi not found')
+
+    logging.info(f'Logging in as {username} with GSSAPI')
+
+    callback = GSSAPI_handler(server, username)
+    resp = imap.authenticate("GSSAPI", callback)
+    if resp[0] != 'OK':
+        raise Exception(f'GSSAPI login failed with {resp} as user {username} on {server}')
 
 def scan_msgs(configfile:str, verbose:bool) -> None:
     conf = configparser.ConfigParser()
@@ -133,7 +185,13 @@ def scan_msgs(configfile:str, verbose:bool) -> None:
                            port=int(conf.get('retriever', 'port', fallback=993)),
                            ssl_context=ctx) as imap:
         username:str = conf.get('retriever', 'username')
-        auth_builtin(username, imap, conf, server)
+        use_kerberos = conf.getboolean('retriever', 'use_kerberos',
+                                       fallback=False)
+        if use_kerberos:
+            auth_gssapi(username, imap, conf, server)
+        else:
+            auth_builtin(username, imap, conf, server)
+
         if verbose: # only enable debugging after login to avoid leaking credentials in the log
             imap.debug = 4
         logging.info("capabilities reported: %s", ', '.join(imap.capabilities))

--- a/imap-dl
+++ b/imap-dl
@@ -116,6 +116,10 @@ def scan_msgs(configfile:str, verbose:bool) -> None:
                         '(found "{on_size_mismatch_str}")')
 
     ctx = ssl.create_default_context(cafile=ca_certs)
+    ssl_ciphers = conf.get('retriever', 'ssl_ciphers', fallback=None)
+    if ssl_ciphers:
+        ctx.set_ciphers(ssl_ciphers)
+
     server:str = conf.get('retriever', 'server')
     with imaplib.IMAP4_SSL(host=server, #type: ignore
                            port=int(conf.get('retriever', 'port', fallback=993)),

--- a/imap-dl.1.pod
+++ b/imap-dl.1.pod
@@ -2,7 +2,7 @@
 
 =head1 NAME
 
-imap-dl -- a simple replacement for a minimalist user of getmail
+imap-dl -- fetch messages from an IMAP inbox into a maildir
 
 =head1 SYNOPSIS
 
@@ -10,35 +10,61 @@ B<imap-dl> [B<-v>|B<--verbose>] B<configfile>...
 
 =head1 DESCRIPTION
 
+B<imap-dl> tries to retrieve all messages from an IMAP inbox and put
+them in a maildir.
+
 If you use getmail to reach an IMAP server as though it were POP
 (retrieving from the server, storing it in a maildir and optionally
-deleting), you can point this script to the getmail config and it
-should do the same thing.
+deleting), you can point this script to the getmail configfile and it
+should do the same thing.  While the minimal configuration file
+matches the syntax for common getmail configurations, some other
+options might be specific to B<imap-dl>.
 
-It tries to ensure that the configuration file is of the expected
-type, and otherwise it will terminate with an error.  It should not
-lose e-mail messages.
+B<imap-dl> tries to ensure that the configuration file is of the
+expected type, and otherwise it will terminate with an error.  It
+should never lose e-mail messages.
 
 If there's any interest in supporting other similarly simple use cases
-for getmail, patches are welcome.
+for fetching messages from an IMAP account into a maildir, patches are
+welcome.
 
 =head1 OPTIONS
 
 B<-v> or B<--verbose> causes B<imap-dl> to print more details
 about what it is doing.
 
+=head1 CONFIGFILE OPTIONS
+
+B<imap-dl> uses an ini-style configfile, with [Sections] which each
+have keyword arguments within them.  We use the syntax B<foo.bar> here
+to mean keyword B<bar> in section B<foo>.  B<imap-dl> inherits some
+basic configuration options from B<getmail>, including the following
+options:
+
+B<retriever.server> is the dns name of the mailserver.
+
+B<retriever.username> is the username of the IMAP account.
+
+B<retriever.password> is the password for the IMAP account when using
+plaintext passwords.
+
+B<destination.path> is the location of the target maildir.
+
+B<options.delete> is a boolean, whether to delete the messages that
+were successfully retreived (default: false).
+
 In addition to parts of the standard B<getmail> configuration,
-B<imap-dl> supports the following keywords in the config file:
+B<imap-dl> supports the following keywords in the configfile:
 
 B<options.on_size_mismatch> can be set to B<error>, B<none>, or
 B<warn>.  This governs what to do when the remote IMAP server claims a
 different size in the message summary list than the actual message
 retrieval (default: B<error>).
 
-=head1 EXAMPLE CONFIG
+=head1 EXAMPLE CONFIGFILE
 
-If you've never used getmail, you can make the simplest possible
-config file like so:
+This configfile fetches all the mail from the given IMAP account's
+inbox, and deletes the messages when they are successfully fetched:
 
 =over 4
 

--- a/imap-dl.1.pod
+++ b/imap-dl.1.pod
@@ -48,6 +48,10 @@ B<retriever.username> is the username of the IMAP account.
 B<retriever.password> is the password for the IMAP account when using
 plaintext passwords.
 
+B<retriever.ssl_ciphers> is an OpenSSL cipher string to use instead of the
+defaults.  (The defaults are good; this should be avoided except to work
+around bugs.)
+
 B<destination.path> is the location of the target maildir.
 
 B<options.delete> is a boolean, whether to delete the messages that

--- a/imap-dl.1.pod
+++ b/imap-dl.1.pod
@@ -48,6 +48,10 @@ B<retriever.username> is the username of the IMAP account.
 B<retriever.password> is the password for the IMAP account when using
 plaintext passwords.
 
+B<retriever.use_kerberos> (boolean) requests that Kerberos (through GSSAPI) is
+to be used instead of password-based auth.  There is no need to specify
+password when using Kerberos.  This requires the python3-gssapi module.
+
 B<retriever.ssl_ciphers> is an OpenSSL cipher string to use instead of the
 defaults.  (The defaults are good; this should be avoided except to work
 around bugs.)


### PR DESCRIPTION
Refactoring commit is separate to keep the diff readable; it's fine to squash if you prefer.

This adds an optional dependency on [python3-gssapi](https://github.com/pythongssapi/python-gssapi/).  In full disclosure, I am an author of that library; I'm also the author of the GSSAPI support in offlineimap (which is why the code probably looks similar).  Unfortunately we don't have type annotations; I've looked into adding them, but using mypy with cython code doesn't seem to work (yet?).

Tested against a Kerberized Zimbra instance.  `ssl_ciphers` support is unfortunately needed for my local site, so it's first in the series.

Thanks!